### PR TITLE
fix: prevent auth from reset on login

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 import { validateCredentials } from '@/lib/rabbitmq/client'
-import { setSessionCookie } from '@/lib/auth/session'
+import { COOKIE_NAME, createSession, sessionCookieOptions } from '@/lib/auth/session'
 import { classifyError } from '@/lib/rabbitmq/errors'
 import type { RabbitMQUser } from '@/lib/rabbitmq/types'
 
@@ -25,9 +25,14 @@ export async function POST(request: Request) {
     }
 
     const credentials = Buffer.from(`${username}:${password}`).toString('base64')
-    setSessionCookie(credentials, user)
+    const response = NextResponse.json({ authenticated: true, user })
+    response.cookies.set(
+      COOKIE_NAME,
+      JSON.stringify(createSession(credentials, user)),
+      sessionCookieOptions(request),
+    )
 
-    return NextResponse.json({ authenticated: true, user })
+    return response
   } catch (err) {
     const error = classifyError(err)
     return NextResponse.json({ error: error.message }, { status: error.status })

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server'
-import { clearSessionCookie } from '@/lib/auth/session'
+import { COOKIE_NAME } from '@/lib/auth/session'
 
 export async function POST() {
-  clearSessionCookie()
-  return NextResponse.json({ success: true })
+  const response = NextResponse.json({ success: true })
+  response.cookies.delete(COOKIE_NAME)
+  return response
 }

--- a/lib/auth/session.ts
+++ b/lib/auth/session.ts
@@ -1,39 +1,36 @@
-import { cookies } from 'next/headers'
 import type { AuthSession, RabbitMQUser } from '@/lib/rabbitmq/types'
 
-const COOKIE_NAME = 'rmq-session'
+export const COOKIE_NAME = 'rmq-session'
 
 /**
- * Set the auth session cookie (server-side only).
+ * Create the value stored in the auth session cookie.
  */
-export function setSessionCookie(credentials: string, user: RabbitMQUser): void {
-  const session: AuthSession = { credentials, user }
+export function createSession(credentials: string, user: RabbitMQUser): AuthSession {
+  return { credentials, user }
+}
 
-  cookies().set(COOKIE_NAME, JSON.stringify(session), {
+/**
+ * Determine whether the session cookie should use the Secure attribute.
+ */
+export function isSecureRequest(request: Request): boolean {
+  const forwardedProto = request.headers.get('x-forwarded-proto')?.split(',')[0]?.trim()
+
+  if (forwardedProto) {
+    return forwardedProto === 'https'
+  }
+
+  return new URL(request.url).protocol === 'https:'
+}
+
+/**
+ * Build the shared options used when setting the auth session cookie.
+ */
+export function sessionCookieOptions(request: Request) {
+  return {
     httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
-    sameSite: 'lax',
+    secure: isSecureRequest(request),
+    sameSite: 'lax' as const,
     path: '/',
     maxAge: 60 * 60 * 24, // 24 hours
-  })
-}
-
-/**
- * Clear the auth session cookie (server-side only).
- */
-export function clearSessionCookie(): void {
-  cookies().delete(COOKIE_NAME)
-}
-
-/**
- * Read the auth session from the cookie (server-side only).
- */
-export function getSessionFromCookie(): AuthSession | null {
-  try {
-    const cookie = cookies().get(COOKIE_NAME)
-    if (!cookie?.value) return null
-    return JSON.parse(cookie.value) as AuthSession
-  } catch {
-    return null
   }
 }


### PR DESCRIPTION
Closes https://github.com/Ralve-org/RabbitScout/issues/19

I fixed auth cookie persistence by setting/deleting rmq-session directly on the NextResponse in login/logout routes.